### PR TITLE
Fork to backgroun by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ sudo ./disk_indicator <method> [params]
        environment use this flag to avoid getting your LEDs reset.
 -c     Use standard TTY console interface to control LEDs.
 -t     Use ACPI to set LEDs on ThinkPad laptops.
+-f     Do not fork to background.
 
 X.Org params: [led]
 num    Use NumLock.

--- a/src/main.c
+++ b/src/main.c
@@ -162,17 +162,17 @@ void handle_signal(int number)
 /**
  * Check if we're attached to a terminal
  */
-int InTerm(void)
+int isattached(void)
 {
         return isatty(fileno(stdout) && isatty(fileno(stdin)) && isatty(fileno(stderr)));
 }
 
 /**
- * Fork to background and detach from console
+ * Fork/daemonize to background and detach from console
  */
-void Fork(void)
+void daemonize(void)
 {
-        if (InTerm())
+        if (isattached())
         {
                 int i = fork();
 
@@ -198,6 +198,7 @@ void Fork(void)
 
 int main(int argc, const char *argv[])
 {
+	int nofork = 0;
 	// show help if no arguments are specified
 	if ((argc == 1) || (strcmp(argv[1], "-h") == 0) || (strcmp(argv[1], "--help") == 0)) {
 		printf(
@@ -205,7 +206,8 @@ int main(int argc, const char *argv[])
 			"Methods:\n"
 			"\t-x\tUse X.Org server to set keyboard LEDs.\n"
 			"\t-c\tUse TTY console interfact to set keyboard LEDs.\n"
-			"\t-t\tUse ThinkPad LEDs for notification.\n\n"
+			"\t-t\tUse ThinkPad LEDs for notification.\n"
+			"\t-f\tDo not fork to background.\n\n"
 			"X.Org parameters: [led]\n"
 			"\tnum\tUse NumLock\n"
 			"\tcap\tUse CapsLock\n"
@@ -220,6 +222,8 @@ int main(int argc, const char *argv[])
 			"\t0-15\n"
 		);
 		exit(EXIT_SUCCESS);
+	} else if ((strcmp(argv[1], "-f") == 0)) {
+		nofork = 1;
 	}
 
 	// register signal handler
@@ -235,7 +239,9 @@ int main(int argc, const char *argv[])
 		exit(1);
 	}
 
-    Fork();
+	// Fork to background
+	if (!nofork)
+		daemonize();
 
 	// start main loop
 	while (1) {


### PR DESCRIPTION
This code forks the process to the background and detaches itself from the console, allowing for easy execution and not being dependent on the shell session so when the shell exits the process continues to run.

Let me know if any changes should be made.
